### PR TITLE
Contact Info Display Change

### DIFF
--- a/project-fds/src/pages/Contact/Contact.js
+++ b/project-fds/src/pages/Contact/Contact.js
@@ -49,22 +49,21 @@ const Contact = () => {
 		<main className="Contact">
 			<h1 className = "contact_info_title">Contact Us</h1>
 			<div className="contact_info_information">
-				<div>
-					Email: joeerenberger@gmail.com
-				</div>
-				<div>
-					Phone: (309)-292-2777
-				</div>
-				<div>
+				
+				<span className="contact_info_company_title">
+					Insight Management and Rentals
+				</span>
+				<span>
 					Address:
 					230 West 3rd St., Suite 216
 					Davenport, IA, 52801
-				</div>
-				<div className="contact_info_company_title">
-					Insight Management and Rentals
-				</div>
-				{/* these divs are in here backward because I want the text to align right
-					but floating right makes it order backwards so this has to happen */}
+				</span>
+				<span>
+					Email: joeerenberger@gmail.com
+				</span>
+				<span>
+					Phone: (309)-292-2777
+				</span>
 			</div>
 			<div className="contact_info_form_wrapper">
 				<Form>

--- a/project-fds/src/pages/Contact/style.css
+++ b/project-fds/src/pages/Contact/style.css
@@ -6,14 +6,12 @@
 .contact_info_information
 {
     clear:left;
-    float:right;
     width:100%;
 }
-.contact_info_information *
+.contact_info_information span
 {
-    float:right;
-    padding-right:2rem;
-    padding-left:2rem;
+    padding-right:1rem;
+    display: inline-flex;
 }
 .contact_info_title
 {


### PR DESCRIPTION
The contact information section now defaults to 1 line if there's room, and "piles" each piece of information as is necessary as the screen gets smaller. I also made it contained in span tags instead of divs, since they don't need to line break after each one. Additionally, the lack of floating made it so the spans don't have to be backward anymore! yay!